### PR TITLE
Run/stop Renpy game

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -113,13 +113,13 @@ Key VSCode plugin implementation points:
 
 * Integration
 
+- [X] Run renpy commands
+
+- [X] flymake + renpy lint
+
 - [ ] Ren'py launcher integration (see https://github.com/elizagamedev/renpy-mode)
 
-- [ ] renpy lint + flymake
-
-- [ ] renpy compile
-
-- [ ] Suggest for inclusion to Ren'py itself
+  - [ ] Suggest for inclusion to Ren'py itself
 
 - [ ] display images through a popup window or a tooltip
 
@@ -132,9 +132,6 @@ Key VSCode plugin implementation points:
   https://github.com/renpy/vscode-language-renpy/blob/master/snippets/snippets.json
 
 - [ ] block folding (or just outline-minor-mode support?)
-
-
-- [X] flymake + renpy lint
 
 * Document
 


### PR DESCRIPTION
Building on the Flymake integration work is a way to run/stop the current game right from Emacs.

The PR provides two functions (run-renpy, renpy-stop) that make it easy to launch the game defined by the dominating `game/` directory.

@morganwillcock hope this patch makes sense to you. Thanks!