### PR TITLE
Github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version:
+          - 27.2
+          - 28.2
+          - 29.4
+          - 30.1
+        experimental: [false]
+        include:
+        - os: ubuntu-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: macos-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: windows-latest
+          emacs-version: snapshot
+          experimental: true
+        exclude:
+        - os: macos-latest
+          emacs-version: 27.2
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: jcs090218/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
+
+    - name: Run tests
+      run: |
+        eask clean all
+        eask package
+        eask install
+        eask compile
+        eask test ert-runner


### PR DESCRIPTION
As discussed elsewhere, it is nice to have a CI pipeline set up for the project.

This PR implements a Github Workflow that compiles the package and runs all tests in Emacs 27/28/29/30, Windows/MacOS/Linux. Note that running tests on Emacs 27 / MacOS is excluded as this Emacs version is not available.

To be honest, it's great that all three major platforms are tested automatically, even if one of them doesn't check the oldest Emacs version renpy-mode supports.

@morganwillcock what do you think?